### PR TITLE
Update 900000-exclusion_rules.xml

### DIFF
--- a/Exclusion Rules/900000-exclusion_rules.xml
+++ b/Exclusion Rules/900000-exclusion_rules.xml
@@ -188,7 +188,7 @@
   </rule>
   <!-- Lower Sev for Executable file dropped in folder commonly used by malware. Triggers many FPs due to user's browsers -->
   <rule id="900030" level="8">
-    <if_sid>92204</if_sid>
+    <if_sid>92213</if_sid>
     <description>Executable file dropped in folder commonly used by malware.</description>
     <options>no_full_log</options>
   </rule>


### PR DESCRIPTION
In Wazuh 4.4 92204 is for powershell creating executables, but 92213 is for any process to create an executable.   Maybe it could be <if_sid>92204,92213</if_sid> to cover off both scenarios.   Even level 8 may be high for this type of activity.