### PR TITLE
Resolved bug into malicious-powershell

### DIFF
--- a/Windows Powershell/malicious-powershell
+++ b/Windows Powershell/malicious-powershell
@@ -95,7 +95,7 @@ Get-WMIRegCachedRDPConnection:
 Get-RegistryMountedDrive:
 Get-WMIRegMountedDrive:
 Get-NetProcess:
-Get-WMIProcess
+Get-WMIProcess:
 Find-InterestingFile:
 Invoke-UserHunter:
 Find-DomainUserLocation:


### PR DESCRIPTION
There was no delimiter inside the file, which made inserting into wazuh a problem as it made the cbd list not visible inside the dashboard.