### PR TITLE
Fixing case misalignment between Linux and Windows sysmon event ID field name

### DIFF
--- a/Sysmon Linux/200150-sysmon_for_linux_rules.xml
+++ b/Sysmon Linux/200150-sysmon_for_linux_rules.xml
@@ -7,7 +7,7 @@
 <group name="linux,sysmon,">
     <rule id="200150" level="3">
         <decoded_as>sysmon-linux</decoded_as>
-        <field name="system.eventId">\.+</field>
+        <field name="system.eventID">\.+</field>
         <description>Sysmon For Linux Event</description>
         <mitre>
          <id>T1204</id>
@@ -17,7 +17,7 @@
 <!--EventID = 1-->
     <rule id="200151" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^1$</field>
+        <field name="system.eventID">^1$</field>
         <description>Sysmon - Event 1: Process creation $(eventdata.image)</description>
         <group>sysmon_event1</group>
         <mitre>
@@ -28,7 +28,7 @@
 <!--EventID = 3-->
     <rule id="200152" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^3$</field>
+        <field name="system.eventID">^3$</field>
         <description>Sysmon - Event 3: Network connection by $(eventdata.image)</description>
         <group>sysmon_event3</group>
         <mitre>
@@ -39,7 +39,7 @@
 <!--EventID = 5-->
     <rule id="200153" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^5$</field>
+        <field name="system.eventID">^5$</field>
         <description>Sysmon - Event 5: Process terminated $(eventdata.image)</description>
         <group>sysmon_event5</group>
         <mitre>
@@ -50,7 +50,7 @@
 <!--EventID = 9-->
     <rule id="200154" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^9$</field>
+        <field name="system.eventID">^9$</field>
         <description>Sysmon - Event 9: Raw Access Read by $(eventdata.image)</description>
         <group>sysmon_event9</group>
         <mitre>
@@ -61,7 +61,7 @@
 <!--EventID = 11-->
     <rule id="200155" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^11$</field>
+        <field name="system.eventID">^11$</field>
         <description>Sysmon - Event 11: FileCreate by $(eventdata.image)</description>
 	      <group>sysmon_event_11</group>
         <mitre>
@@ -72,7 +72,7 @@
 <!--EventID = 16-->
     <rule id="200156" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^16$</field>
+        <field name="system.eventID">^16$</field>
         <description>Sysmon - Event 16: Sysmon config state changed $(Event.EventData.Data.Configuration)</description>
         <group>sysmon_event_16</group>
         <mitre>
@@ -83,7 +83,7 @@
 <!--EventID = 23-->
     <rule id="200157" level="3">
         <if_sid>200150</if_sid>
-        <field name="system.eventId">^23$</field>
+        <field name="system.eventID">^23$</field>
         <description>Sysmon - Event 23: FileDelete (A file delete was detected) by $(eventdata.image)</description>
         <group>sysmon_event_23</group>
         <mitre>

--- a/Sysmon Linux/decoder-linux-sysmon.xml
+++ b/Sysmon Linux/decoder-linux-sysmon.xml
@@ -7,7 +7,7 @@
 <decoder name="sysmon-linux-child">
   <parent>sysmon-linux</parent>
   <regex offset="after_parent">\pEventID\p(\d+)\p/EventID\p</regex>
-  <order>system.eventId</order>
+  <order>system.eventID</order>
 </decoder>
 
 <!-- keywords -->


### PR DESCRIPTION
It appears you are basing your Sysmon for Linux decoded field names off of the Windows Sysmon equivalent field names, which I think is a great idea.
I did note one inconsistency, though, in that Windows Sysmon's event ID field name ends with "system.eventID" while you are decoding Linux Sysmon event ID fields under the name "system.eventId" (lowercase final letter).  This PR is my proposal to bring that field into case alignment with the Windows side.
Thanks so much for your valuable contributions to the Wazuh open source community!