### PR TITLE
Fix typo in malicious-powershell

### DIFF
--- a/Windows Powershell/malicious-powershell
+++ b/Windows Powershell/malicious-powershell
@@ -95,7 +95,7 @@ Get-WMIRegCachedRDPConnection:
 Get-RegistryMountedDrive:
 Get-WMIRegMountedDrive:
 Get-NetProcess:
-Get-WMIProcess
+Get-WMIProcess:
 Find-InterestingFile:
 Invoke-UserHunter:
 Find-DomainUserLocation:


### PR DESCRIPTION
Fix typo in line Get-WMIProcess causing the import of list to error out.