### PR TITLE
Added unzip logging rule to support detection of steganography-based attacks

### DIFF
--- a/Auditd/auditd.conf
+++ b/Auditd/auditd.conf
@@ -348,6 +348,7 @@
 ## T1002 Data Compressed
 
 -w /usr/bin/zip -p x -k T1002_Data_Compressed
+-w /usr/bin/unzip -p x -k T1002_Data_Compressed
 -w /usr/bin/gzip -p x -k T1002_Data_Compressed
 -w /usr/bin/tar -p x -k T1002_Data_Compressed
 -w /usr/bin/bzip2 -p x -k T1002_Data_Compressed


### PR DESCRIPTION
Included audit rule for /usr/bin/unzip execution to align with Sigma rule: https://github.com/SigmaHQ/sigma/blob/master/rules/linux/auditd/lnx_auditd_unzip_hidden_zip_files_steganography.yml

This enables detection of attempts to extract hidden zip content from image files (e.g., .jpg, .png) as part of MITRE ATT&CK T1027 (Obfuscated Files or Information).

Corresponding Wazuh rule:
```xml
<rule id="200185" level="12">
  <if_sid>200111</if_sid>
  <field name="audit.execve.a0">unzip</field>
  <field name="audit.execve.a1">.jpg$|.png$</field>
  <description>Detects extracting of zip file from image file.</description>
  <mitre><id>T1027</id></mitre>
  <group>execve</group>
</rule>
```