### PR TITLE
fix: escape dollar sign in rule 101344 to resolve Wazuh XML variable parsing error

### DIFF
--- a/Windows Powershell/100535-win_powershell_rules.xml
+++ b/Windows Powershell/100535-win_powershell_rules.xml
@@ -519,9 +519,9 @@
 
   <rule id="101344" level="10">
     <if_sid>91802</if_sid>
-    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\$doit</field>
+    <field name="win.eventdata.scriptBlockText" type="pcre2">(?i)\x24doit</field>
     <options>no_full_log</options>
-    <description>Powershell script: $doit variable detected (exploit scripts)</description>
+    <description>Powershell script: 'doit' variable detected (exploit scripts)</description>
     <mitre><id>T1059.001</id></mitre>
   </rule>
 


### PR DESCRIPTION
## What does this PR do?
Fixes rule 101344 (PowerShell $doit variable detection) which was
causing Wazuh to fail on startup with the following error:

wazuh-analysisd: ERROR: (1227): Error applying XML variables
'etc/rules/100535-win_powershell_rules.xml': XMLERR: Unknown
variable: 'doit'

## Root Cause
The `$` character in both the regex field and description tag was
being interpreted by Wazuh's XML parser as a variable declaration
rather than a literal dollar sign — causing the rules engine to
crash on startup.

## Fix
Two changes made to rule 101344:

1. Regex field — replaced `\$doit` with `\x24doit`
   `\x24` is the PCRE2 hex escape for the `$` character, bypassing
   the XML variable parser entirely

2. Description field — removed raw `$doit`, replaced with `'doit'`
   to prevent the parser from attempting variable resolution

## Testing
- Validated with: sudo /var/ossec/bin/wazuh-analysisd -t
- Confirmed rule fires correctly via wazuh-logtest
- Wazuh manager restarts cleanly with no errors

## References
- Wazuh XML variable parsing docs:
  https://documentation.wazuh.com/current/user-manual/ruleset/ruleset-xml-syntax/rules.html

## This fixes : Issue #44 